### PR TITLE
Remediate deprecation of Express' req.params

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -14,7 +14,7 @@
       SLACK_SIGNING_SECRET=Signing Secret
 - Let's get the org-wide app management token
   - In two separate terminals:
-    - Start the OAuth token helper: `ts-node auth.js`, it will listen on port 5000 by default
+    - Start the OAuth token helper: `ts-node auth.ts`, it will listen on port 5000 by default
     - Start up your favorite reverse proxy/tunneler, for example: `ngrok http 5000`
   - From your Slack App Config page (https://api.slack.com/apps):
     - On the OAuth & Permssions page, set your Redirect URL to `https://YOUR_UNIQUE_ID.ngrok.io/redirect/oauth`
@@ -23,7 +23,7 @@
       - On the Manage Distribution page, click "Add to Slack"
       - Make sure you are installing to an Organization (and not a Workspace)
       - After clicking "Allow", you will be redirected to a page displaying a token which starts with `xoxp-...`
-    - Stop the two processes you started (`ts-node auth.js` and the reverse proxy/tunnel)
+    - Stop the two processes you started (`ts-node auth.ts` and the reverse proxy/tunnel)
 - Similar to how you set the `SLACK_CLIENT_ID` and other variables above, set `SLACK_USER_TOKEN` in `.env` to the `xoxp-...` token you received in the previous step
 - Set `MONGO_URI` to the full URI (including `mongodb://`) of a Mongo server you have access to
 

--- a/auth.ts
+++ b/auth.ts
@@ -19,7 +19,7 @@ const port = 5000
 authApp.get('/redirect/oauth', function (req, res) {
     const client_id = process.env.SLACK_CLIENT_ID;
     const client_secret = process.env.SLACK_CLIENT_SECRET;
-    const code = req.params["code"];
+    const code = req.query.code;
     const url = `https://slack.com/api/oauth.v2.access?code=${code}&client_id=${client_id}&client_secret=${client_secret}`
     res.redirect(url);
 });


### PR DESCRIPTION
###  Summary
- Fixes typo of `auth.js` to `auth.ts` in `SETUP.md`
- Fixes bug #19 related to deprecation of `req.params["code"]` syntax in [Express](https://stackoverflow.com/questions/28949266/replacement-for-req-param-that-is-deprecated-in-express-4) 

### Requirements
* [x] I've read and understood the [Contributing guidelines](../CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
